### PR TITLE
Test: exercise CrAT reachability gate

### DIFF
--- a/GATE_TEST.md
+++ b/GATE_TEST.md
@@ -1,0 +1,3 @@
+# CrAT gate test
+
+Trivial change to open a PR that exercises the CrAT reachability gate.


### PR DESCRIPTION
Trivial change to confirm the CrAT reachability gate runs as a PR check. Expected: gate fails on the reachable HIGH advisories in next@16.